### PR TITLE
Support Ruby 2.2.2 and later

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,23 +1,32 @@
+require:
+  - rubocop-performance
+
 AllCops:
-  NewCops: enable
-  SuggestExtensions: false
-  TargetRubyVersion: 2.1.1
+  # NewCops: enable
+  # SuggestExtensions: false
+  TargetRubyVersion: 2.2.2
 
 Layout/AccessModifierIndentation:
   Enabled: true
 
-Layout/LineLength:
-  Max: 100
+# Layout/LineLength:
+#   Max: 100
 
 Metrics/BlockLength:
   Max: 25
+
+Metrics/LineLength:
+  Max: 100
+
+Style/AccessModifierDeclarations:
+  Enabled: false # bug in Rubocop v0.68.1 (required for Ruby 2.2.2)
 
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: never
 
-Style/OptionalBooleanParameter:
-  Enabled: false
+# Style/OptionalBooleanParameter:
+#   Enabled: false
 
 Style/PreferredHashMethods:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   NewCops: enable
   SuggestExtensions: false
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.1.1
 
 Layout/AccessModifierIndentation:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and, as of version 0.3.0 and later, this project adheres to [Semantic Versioning
 ## [Unreleased]
 ### Changed
 - Updated README reference links
+- Updated to support Ruby 2.1 as minimum (instead of 2.5)
+- Refreshed development gems
 
 ## [1.1.0] - 2021-08-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ The format is based on [Keep a Changelog (1.0.0)](https://keepachangelog.com/en/
 and, as of version 0.3.0 and later, this project adheres to [Semantic Versioning (2.0.0)](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Optional specs for developers to check Loba performance (no surprising issues found)
+
 ### Changed
 - Updated README reference links
-- Updated to support Ruby 2.1 as minimum (instead of 2.5)
-- Refreshed development gems
+- Updated to support Ruby 2.2.2 as minimum (retreated from 2.5)
+- Refactored to seperate stripping quotes from .inspect-generated strings
 
 ## [1.1.0] - 2021-08-20
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ end
 group :test do
   gem 'codeclimate-test-reporter', require: nil
   gem 'rspec'
+  gem 'ruby-prof'
   gem 'simplecov', require: false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,9 @@ gemspec
 
 group :development do
   gem 'rubocop', require: false
+  gem 'rubocop-performance', require: false
   gem 'rubocop-rspec', require: false
+
   gem 'yard', require: false
 end
 

--- a/lib/loba/internal.rb
+++ b/lib/loba/internal.rb
@@ -5,18 +5,23 @@ require_relative 'internal/value'
 module Loba
   # @api private
   module Internal
-    def strip_quotes(content)
+    # Remove wrapping quotes on a string (produced by .inspect)
+    #
+    # @param argument [String] the string (assumed to be produced from calling .inspect)
+    #   to remove quotes (") that wrap a string
+    #
+    # @return [String, Object]
+    #   * If not a string, the original argument will be returned without modification
+    #   * If string does not have quotes as first and last character, the original
+    #     argument will be returned without modification
+    #   * If string does have quotes as first and last character, the original content
+    #     will be returned with the original first and last character removed
+    def unquote(content)
       return content unless content.is_a?(String)
       return content unless content[0] == '"' && content[-1] == '"'
 
-      if content.respond_to?(:delete_prefix)
-        content.delete_prefix('"').delete_suffix('"')
-      elsif content.respond_to?(:gsub)
-        content.gsub(/\A"+|"+\z/, '')
-      else
-        content
-      end
+      content[1...-1]
     end
-    module_function :strip_quotes
+    module_function :unquote
   end
 end

--- a/lib/loba/internal.rb
+++ b/lib/loba/internal.rb
@@ -5,5 +5,18 @@ require_relative 'internal/value'
 module Loba
   # @api private
   module Internal
+    def strip_quotes(content)
+      return content unless content.is_a?(String)
+      return content unless content[0] == '"' && content[-1] == '"'
+
+      if content.respond_to?(:delete_prefix)
+        content.delete_prefix('"').delete_suffix('"')
+      elsif content.respond_to?(:gsub)
+        content.gsub(/\A"+|"+\z/, '')
+      else
+        content
+      end
+    end
+    module_function :strip_quotes
   end
 end

--- a/lib/loba/internal/value.rb
+++ b/lib/loba/internal/value.rb
@@ -27,7 +27,7 @@ module Loba
       #   * :label => [String] label, ending with ":"
       #     (if not possible to infer, '[unknown value]' is returned)
       def phrases(argument:, label: nil, inspect: true, depth_offset: 0)
-        depth = depth_offset&.to_i || 0
+        depth = depth_offset.nil? ? 0 : depth_offset.to_i
         {
           tag: ValueHelper.tag(depth: depth + 1),
           line: ValueHelper.line(depth: depth + 1),

--- a/lib/loba/internal/value/value_helper.rb
+++ b/lib/loba/internal/value/value_helper.rb
@@ -38,7 +38,7 @@ module Loba
 
           # #inspect adds explicit quotes to strings, so strip back off since #inspect
           # always returns a String
-          val = Loba::Internal.strip_quotes(val) if inspect
+          val = Loba::Internal.unquote(val) if inspect
 
           # make nils obvious
           val.nil? ? '-nil-' : val.to_s

--- a/lib/loba/internal/value/value_helper.rb
+++ b/lib/loba/internal/value/value_helper.rb
@@ -38,9 +38,7 @@ module Loba
 
           # #inspect adds explicit quotes to strings, so strip back off since #inspect
           # always returns a String
-          if inspect && val.respond_to?(:delete_prefix)
-            val = val.delete_prefix('"').delete_suffix('"')
-          end
+          val = Loba::Internal.strip_quotes(val) if inspect
 
           # make nils obvious
           val.nil? ? '-nil-' : val.to_s

--- a/lib/loba/version.rb
+++ b/lib/loba/version.rb
@@ -1,3 +1,3 @@
 module Loba
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/loba.gemspec
+++ b/loba.gemspec
@@ -25,11 +25,12 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'.freeze
   spec.executables   = spec.files.grep(/^exe\//) { |f| File.basename(f) }
   spec.require_paths = ['lib'.freeze]
-  spec.required_ruby_version = '>= 2.1.1'
+  spec.required_ruby_version = '>= 2.2.2'
 
   spec.metadata = {
     'source_code_uri' => 'https://github.com/rdnewman/loba',
     'bug_tracker_uri' => 'https://github.com/rdnewman/loba/issues',
+    'changelog_uri' => 'https://github.com/rdnewman/loba/CHANGELOG.md',
     'documentation_uri' => 'https://www.rubydoc.info/gems/loba'
   }
 

--- a/loba.gemspec
+++ b/loba.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'.freeze
   spec.executables   = spec.files.grep(/^exe\//) { |f| File.basename(f) }
   spec.require_paths = ['lib'.freeze]
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.1.1'
 
   spec.metadata = {
     'source_code_uri' => 'https://github.com/rdnewman/loba',
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
     'documentation_uri' => 'https://www.rubydoc.info/gems/loba'
   }
 
-  spec.add_development_dependency 'bundler', '~> 2.2'
+  spec.add_development_dependency 'bundler'
 
   spec.add_dependency 'binding_of_caller', '~> 1.0'
   spec.add_dependency 'rainbow', '~> 3.0'

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -19,8 +19,8 @@ RSpec/ExampleLength:
 RSpec/MessageExpectation:
   Enabled: true
 
-RSpec/MultipleMemoizedHelpers:
-  Enabled: false
+# RSpec/MultipleMemoizedHelpers:
+#   Enabled: false
 
 RSpec/NestedGroups:
   Enabled: true

--- a/spec/loba/loba/internal/platform_spec.rb
+++ b/spec/loba/loba/internal/platform_spec.rb
@@ -9,6 +9,24 @@ RSpec.describe Loba::Internal::Platform do
     expect(platform.logger).to be_a(Proc)
   end
 
+  it 'cannot be called directly as part of Loba' do
+    test_class = Class.new do
+      def hello
+        Loba.rails?
+      end
+    end
+    expect { test_class.new.hello }.to raise_error NameError
+  end
+
+  it 'can be called if fully namespaced' do
+    test_class = Class.new do
+      def hello
+        Loba::Internal::Platform.rails?
+      end
+    end
+    expect { test_class.new.hello }.not_to raise_error
+  end
+
   context 'when not in Rails,' do
     before { hide_const('Rails') } # just to be sure
 

--- a/spec/loba/loba/internal/value_spec.rb
+++ b/spec/loba/loba/internal/value_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Loba::Internal::Value do
     let(:value_used_in_mocked_class) do
       # since Valuation, by default, uses .inspect, need to account for either possibility
       if inspection
-        Loba::Internal.strip_quotes(object.class.content.inspect.to_s)
+        Loba::Internal.unquote(object.class.content.inspect.to_s)
       else
         object.class.content.to_s
       end

--- a/spec/loba/loba/internal/value_spec.rb
+++ b/spec/loba/loba/internal/value_spec.rb
@@ -38,8 +38,7 @@ RSpec.describe Loba::Internal::Value do
     let(:value_used_in_mocked_class) do
       # since Valuation, by default, uses .inspect, need to account for either possibility
       if inspection
-        content = object.class.content.inspect.to_s
-        content.delete_prefix('"').delete_suffix('"') if content.respond_to?(:delete_prefix)
+        Loba::Internal.strip_quotes(object.class.content.inspect.to_s)
       else
         object.class.content.to_s
       end

--- a/spec/loba/loba/internal_spec.rb
+++ b/spec/loba/loba/internal_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe Loba::Internal do
+  describe '.strip_quotes' do
+    describe 'strips quotes from' do
+      it 'simple quoted strings' do
+        input = '"some string"'.freeze
+        expected_output = 'some string'.freeze
+        expect(described_class.strip_quotes(input)).to eq expected_output
+      end
+
+      it 'quoted strings that have a new line embedded' do
+        input = '"some\nstring"'.freeze
+        expected_output = 'some\nstring'.freeze
+        expect(described_class.strip_quotes(input)).to eq expected_output
+      end
+    end
+
+    describe 'does not change' do
+      it 'unquoted strings' do
+        input = 'some string'.freeze
+        expected_output = input.freeze
+        expect(described_class.strip_quotes(input)).to eq expected_output
+      end
+
+      it 'strings with only a leading quote' do
+        input = '"some string'.freeze
+        expected_output = input.freeze
+        expect(described_class.strip_quotes(input)).to eq expected_output
+      end
+
+      it 'strings with only a trailing quote' do
+        input = 'some string"'.freeze
+        expected_output = input.freeze
+        expect(described_class.strip_quotes(input)).to eq expected_output
+      end
+
+      it 'quoted strings ending in a new line' do
+        input = '"some string"\n'.freeze
+        expected_output = input.freeze
+        expect(described_class.strip_quotes(input)).to eq expected_output
+      end
+
+      it 'numbers' do
+        input = 5
+        expected_output = input
+        expect(described_class.strip_quotes(input)).to eq expected_output
+      end
+
+      it 'internal values in hashes' do
+        input = { somekey: '"some string"' }
+        expected_output = input
+        expect(described_class.strip_quotes(input)).to eq expected_output
+      end
+    end
+  end
+end

--- a/spec/loba/loba/version_spec.rb
+++ b/spec/loba/loba/version_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Loba::VERSION' do
   let(:parts) { version.match(/(\d+).(\d+)(?:.(\d+))?/) }
   let(:major) { parts[1].to_i }
   let(:minor) { parts[2].to_i }
-  let(:patch) { parts[3]&.to_i }
+  let(:patch) { parts[3].nil? ? nil : parts[3].to_i }
 
   it 'is formatted as major.minor[.patch]' do
     expect(version).to match(/\d+.\d+(?:.\d+)?/)
@@ -15,8 +15,8 @@ RSpec.describe 'Loba::VERSION' do
     expect(major).to eq 1
   end
 
-  it 'is 1.1.x' do
-    expect(minor).to eq 1
+  it 'is 1.2.x or later' do
+    expect(minor).to be > 1
   end
 
   it 'has a patch value' do

--- a/spec/loba/loba/version_spec.rb
+++ b/spec/loba/loba/version_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe 'Loba::VERSION' do
   let(:minor) { parts[2].to_i }
   let(:patch) { parts[3].nil? ? nil : parts[3].to_i }
 
+  it 'has a version number' do
+    expect(version).not_to be nil
+  end
+
   it 'is formatted as major.minor[.patch]' do
     expect(version).to match(/\d+.\d+(?:.\d+)?/)
   end


### PR DESCRIPTION
* Retreated from requiring Ruby 2.5 and later
* Added optional specs for profiling performance of Loba.ts and Loba.val
  * TODO: Loba.val could benefit from reducing multiple calls to `binding.of_caller`