### PR TITLE
Clean gem publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,8 @@ The format is based on [Keep a Changelog (1.0.0)](https://keepachangelog.com/en/
 and, as of version 0.3.0 and later, this project adheres to [Semantic Versioning (2.0.0)](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
-- Fixed loba.gemspec (CHANGELOG link)
 
-## [1.2.0] - 2021-09-05
+## [1.2.1] - 2021-09-05
 ### Added
 - Optional specs for developers to check Loba performance (no surprising issues found)
 
@@ -16,6 +14,8 @@ and, as of version 0.3.0 and later, this project adheres to [Semantic Versioning
 - Updated README reference links
 - Updated to support Ruby 2.2.2 as minimum (retreated from 2.5 for broader support)
 - Refactored to seperate stripping quotes from .inspect-generated strings
+
+## [1.2.0] - 2021-09-05 [YANKED]
 
 ## [1.1.0] - 2021-08-20
 ### Added

--- a/lib/loba/version.rb
+++ b/lib/loba/version.rb
@@ -1,3 +1,3 @@
 module Loba
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.2.1'.freeze
 end

--- a/loba.gemspec
+++ b/loba.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
     'documentation_uri' => 'https://www.rubydoc.info/gems/loba'
   }
 
-  spec.add_development_dependency 'bundler' #, '~> 1.17.3' # can't specify due to older ruby
+  spec.add_development_dependency 'bundler', '~> 2.2' # use 1.17.3 for testing pre-2.5 rubies
 
   spec.add_dependency 'binding_of_caller', '~> 1.0'
   spec.add_dependency 'rainbow', '~> 3.0'


### PR DESCRIPTION
* Reinstated specific bundler version
* Fixed link to CHANGELOG (hopefully)
* Updated version to v1.2.1 (v1.2.0 was yanked)