### PR TITLE
Update for more immediate logging feedback

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,31 +2,24 @@ require:
   - rubocop-performance
 
 AllCops:
-  # NewCops: enable
-  # SuggestExtensions: false
-  TargetRubyVersion: 2.2.2
+  NewCops: enable
+  TargetRubyVersion: 3.0.6
 
 Layout/AccessModifierIndentation:
   Enabled: true
 
-# Layout/LineLength:
-#   Max: 100
+Layout/LineLength:
+  Max: 100
 
 Metrics/BlockLength:
   Max: 25
-
-Metrics/LineLength:
-  Max: 100
-
-Style/AccessModifierDeclarations:
-  Enabled: false # bug in Rubocop v0.68.1 (required for Ruby 2.2.2)
 
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: never
 
-# Style/OptionalBooleanParameter:
-#   Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false
 
 Style/PreferredHashMethods:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and, as of version 0.3.0 and later, this project adheres to [Semantic Versioning
 ## [Unreleased]
 
 ## [2.0.0] - 2023-07-04
+### Added
+- SECURITY.md to specify security policy
+
 ### Changed
 - Dropped support for Ruby prior to 3.0.6
 - Changed output to always write to STDOUT even if Rails is present (in which case it will also log)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and, as of version 0.3.0 and later, this project adheres to [Semantic Versioning
 ### Changed
 - Dropped support for Ruby prior to 3.0.6
 - Changed output to always write to STDOUT even if Rails is present (in which case it will also log)
+- Updated YARD documentation for improved completeness
 
 ## [1.2.1] - 2021-09-05
 ### Added
@@ -87,7 +88,8 @@ and, as of version 0.3.0 and later, this project adheres to [Semantic Versioning
 ### Added
 - Initial implementation
 
-[Unreleased]: https://github.com/rdnewman/loba/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/rdnewman/loba/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/rdnewman/loba/compare/v1.2.1...v2.0.0
 [1.2.1]: https://github.com/rdnewman/loba/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/rdnewman/loba/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/rdnewman/loba/compare/v1.0.0...v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog (1.0.0)](https://keepachangelog.com/en/1.0.0/),
 and, as of version 0.3.0 and later, this project adheres to [Semantic Versioning (2.0.0)](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.0] - 2023-07-04
+### Changed
+- Dropped support for Ruby prior to 3.0.6
+- Changed output to always write to STDOUT even if Rails is present (in which case it will also log)
 
 ## [1.2.1] - 2021-09-05
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -18,5 +18,6 @@ group :test do
 end
 
 group :development, :test do
+  gem 'bundler', '~> 2.4'
   gem 'rake' # for travis-ci
 end

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Easy tracing for debugging: handy methods for adding trace lines to output or Ra
 
 There are two kinds of questions I usually want to answer when trying to diagnose code behavior:
 
-1.  Is this spot of code being reached (or is it reached in the order I think it is)?
-1.  What is the value of this variable?
+1. Is this spot of code being reached (or is it reached in the order I think it is)?
+1. What is the value of this variable?
 
 Loba statements are intended to be terse to minimize typing.
 
@@ -26,7 +26,9 @@ Loba statements are intended to be minimally invasive and atomic. They should no
 
 Loba statements are expected to be removed when you're done with them. No point in cluttering up production code.
 
-Loba will check for presence of Rails. If it's there, it'll write to `Rails.logger.debug`.  If not, it'll write to STDOUT (i.e., `puts`).  Loba will work equally well with or without Rails.
+Loba will always write to STDOUT (i.e., `puts`).
+
+Loba will work equally well with or without Rails. If Rails is present, in addition to STDOUT, Loba will also always write to `Rails.logger.debug`.
 
 Loba uses the [rainbow gem](https://rubygems.org/gems/rainbow) to help make trace statements more visible.
 
@@ -40,7 +42,7 @@ Outputs a timestamped notice, useful for quick traces to see the code path and e
 
 For example,
 
-```
+```text
 [TIMESTAMP] #=0002, diff=93.478016, at=1451444972.970602     (in=/home/usracct/src/myapp/app/models/target.rb:55:in `some_calculation')
 ```
 
@@ -64,7 +66,7 @@ Loba.val :var_sym   # the :var_sym argument is the variable or method name given
 
 For example,
 
-```
+```text
 [Target.some_calculation] my_var: 54       (in /home/usracct/src/myapp/app/models/target.rb:55:in `some_calculation')
 ```
 
@@ -92,7 +94,7 @@ HelloWorld.new.hello
 
 Output:
 
-```
+```text
 [TIMESTAMP] #=0001, diff=0.000463, at=1451615389.505411   (in=/home/usracct/src/lobademo/hello_world.rb:4:in 'initialize'
 [HelloWorld#hello] @x: 42       (in /home/usracct/src/loba/spec/hello_world.rb:9:in `hello')
 Hello, Charlie
@@ -139,11 +141,10 @@ HelloWorld.new.hello
 
 See above Environment Notes if using with Rails.
 
-
 Install as below to be generally available (recommended to restrict to only local use):
 
 ```bash
-$ gem install loba
+gem install loba
 ```
 
 To bundle, add this line to your application's Gemfile:
@@ -160,11 +161,10 @@ or for all environments (for example, if `production: true` used):
 gem 'loba', require: false
 ```
 
-
 And then execute:
 
 ```bash
-$ bundle
+bundle
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ bundle
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`.
+
+To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Changelog
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+Loba is intended for diagnostic use in development and test environments.
+
+Loba assumes consenting adults: it provides an explicit mechanism for temporary use in
+production environments. Use in production environments is not recommended
+and should be treated as insecure. Please see the README.md for additional information.
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities via
+[Github issues](https://github.com/rdnewman/loba/issues).
+For urgent concerns, write to
+**[richard@newmanworks.com](mailto:richard@newmanworks.com)**.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,12 +3,22 @@
 Loba is intended for diagnostic use in development and test environments.
 
 Loba assumes consenting adults: it provides an explicit mechanism for temporary use in
-production environments. Use in production environments is not recommended
-and should be treated as insecure. Please see the README.md for additional information.
+production environments. Use in production environments is NOT recommended
+and should be treated as a security vulnerability. Please see the README.md for
+additional information.
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x.x   | :white_check_mark: |
+| < 2.0   | :x:                |
 
 ## Reporting a Vulnerability
 
 Please report suspected security vulnerabilities via
-[Github issues](https://github.com/rdnewman/loba/issues).
+[Github issues][def].
 For urgent concerns, write to
 **[richard@newmanworks.com](mailto:richard@newmanworks.com)**.
+
+[def]: https://github.com/rdnewman/loba/issues

--- a/lib/loba.rb
+++ b/lib/loba.rb
@@ -52,6 +52,7 @@ module Loba
   module_function :timestamp
 
   # Shorthand alias for Loba.timestamp.
+  # @!method ts(production: false)
   alias ts timestamp
   module_function :ts
 
@@ -122,6 +123,7 @@ module Loba
   module_function :value
 
   # Shorthand alias for Loba.value.
+  # @!method val(argument, label: nil, inspect: true, production: false)
   alias val value
   module_function :val
 end

--- a/lib/loba/internal.rb
+++ b/lib/loba/internal.rb
@@ -3,11 +3,12 @@ require_relative 'internal/time_keeper'
 require_relative 'internal/value'
 
 module Loba
+  # Internal functionality support
   # @api private
   module Internal
     # Remove wrapping quotes on a string (produced by .inspect)
     #
-    # @param argument [String] the string (assumed to be produced from calling .inspect)
+    # @param content [String] the string (assumed to be produced from calling .inspect)
     #   to remove quotes (") that wrap a string
     #
     # @return [String, Object]

--- a/lib/loba/internal/platform.rb
+++ b/lib/loba/internal/platform.rb
@@ -23,7 +23,7 @@ module Loba
         # Returns a logging mechanism appropriate for the application
         def logger
           if rails? && Rails.logger.present?
-            ->(arg) { Rails.logger.debug arg }
+            ->(arg) { puts arg; Rails.logger.debug arg }
           else
             ->(arg) { puts arg }
           end

--- a/lib/loba/internal/platform.rb
+++ b/lib/loba/internal/platform.rb
@@ -3,12 +3,14 @@ module Loba
     # Internal class for managing logging across Rails and non-Rails applications
     class Platform
       class << self
-        # Returns true if Rails appears to be available
+        # Checks if Rails is present
+        # @return [Boolean] true if Rails appears to be available; otherwise, false
         def rails?
           defined?(Rails) ? true : false
         end
 
-        # Returns true if logging is to be allowed
+        # Checks if logging output is permitted.
+        # @return [Boolean] true if logging is to be allowed; otherwise, false
         def logging_ok?(force_true = false)
           return true if force_true
           return true unless rails?
@@ -20,7 +22,8 @@ module Loba
           end
         end
 
-        # Returns a logging mechanism appropriate for the application
+        # Provides logging mechanism appropriate in the application
+        # @return [Lambda] procedure for logging output
         def logger
           if rails? && Rails.logger.present?
             ->(arg) { puts arg; Rails.logger.debug arg }

--- a/lib/loba/internal/time_keeper.rb
+++ b/lib/loba/internal/time_keeper.rb
@@ -15,6 +15,11 @@ module Loba
         reset!
       end
 
+      # Increments timestamping, including attributes `timenum` and `timewas`
+      # @return [Hash] timestamp details
+      #   * :number => [Integer] incremented count of pings so far (attribute `timenum`)
+      #   * :now => [Time] current date and time
+      #   * :change => [Float] difference in seconds from any previous ping or reset
       def ping
         @timenum += 1
         now = Time.now
@@ -24,9 +29,13 @@ module Loba
         { number: @timenum, now: now, change: change }
       end
 
+      # Resets timestamping
+      # @return [NilClass] nil
       def reset!
         @timewas = Time.now
         @timenum = 0
+
+        nil
       end
     end
   end

--- a/lib/loba/internal/value/value_helper.rb
+++ b/lib/loba/internal/value/value_helper.rb
@@ -54,8 +54,8 @@ module Loba
         #     and a label can be inferred.
         #   * If any other type, it is assumed to be a literal value to
         #     and a label should be supplied when instantiated.
-        # @param label [String] when provided, an explicit label to use; will override any
-        #   possible inferred label
+        # @param explicit_label [String] when provided, an explicit label to use; will
+        #   override any possible inferred label
         #
         # @return [String] label
         def label(argument:, explicit_label: nil)

--- a/lib/loba/version.rb
+++ b/lib/loba/version.rb
@@ -1,3 +1,3 @@
 module Loba
-  VERSION = '1.2.1'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/lib/loba/version.rb
+++ b/lib/loba/version.rb
@@ -1,3 +1,4 @@
 module Loba
+  # Semantic version number
   VERSION = '2.0.0'.freeze
 end

--- a/loba.gemspec
+++ b/loba.gemspec
@@ -25,17 +25,16 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'.freeze
   spec.executables   = spec.files.grep(/^exe\//) { |f| File.basename(f) }
   spec.require_paths = ['lib'.freeze]
-  spec.required_ruby_version = '>= 2.2.2'
+  spec.required_ruby_version = '>= 3.0.6'
 
   spec.metadata = {
     'source_code_uri' => 'https://github.com/rdnewman/loba',
     'bug_tracker_uri' => 'https://github.com/rdnewman/loba/issues',
     'changelog_uri' => 'https://github.com/rdnewman/loba/blob/main/CHANGELOG.md',
-    'documentation_uri' => 'https://www.rubydoc.info/gems/loba'
+    'documentation_uri' => 'https://www.rubydoc.info/gems/loba',
+    'rubygems_mfa_required' => 'true'
   }
 
-  spec.add_development_dependency 'bundler', '~> 2.2' # use 1.17.3 for testing pre-2.5 rubies
-
   spec.add_dependency 'binding_of_caller', '~> 1.0'
-  spec.add_dependency 'rainbow', '~> 3.0'
+  spec.add_dependency 'rainbow', '~> 3.1'
 end

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -19,8 +19,8 @@ RSpec/ExampleLength:
 RSpec/MessageExpectation:
   Enabled: true
 
-# RSpec/MultipleMemoizedHelpers:
-#   Enabled: false
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
 
 RSpec/NestedGroups:
   Enabled: true

--- a/spec/loba/loba/internal/platform_spec.rb
+++ b/spec/loba/loba/internal/platform_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Loba::Internal::Platform do
   subject(:platform) { described_class }
 
   it '.logger_ok? is true when force_true is true' do
-    expect(platform.logging_ok?(true)).to eq true
+    expect(platform.logging_ok?(true)).to be true
   end
 
   it '.logger provides a Proc' do
@@ -31,11 +31,11 @@ RSpec.describe Loba::Internal::Platform do
     before { hide_const('Rails') } # just to be sure
 
     it '.rails? is false' do
-      expect(platform.rails?).to eq false
+      expect(platform.rails?).to be false
     end
 
     it '.logging_ok? is true' do
-      expect(platform.logging_ok?).to eq true
+      expect(platform.logging_ok?).to be true
     end
 
     it 'the Proc from .logger writes intended output to STDOUT' do
@@ -61,7 +61,7 @@ RSpec.describe Loba::Internal::Platform do
     end
 
     it '.rails? is true' do
-      expect(platform.rails?).to eq true
+      expect(platform.rails?).to be true
     end
 
     it 'if checking for production environment throws an error, .logging_ok? is true' do
@@ -69,7 +69,7 @@ RSpec.describe Loba::Internal::Platform do
         .to receive(:env).and_return(LobaSpecSupport::MockRails::MockEnvProduction.new)
       allow(mock_rails.env).to receive(:production?).and_raise('mock failure')
 
-      expect(platform.logging_ok?).to eq true
+      expect(platform.logging_ok?).to be true
     end
 
     context 'with logging defined,' do
@@ -101,7 +101,7 @@ RSpec.describe Loba::Internal::Platform do
 
       describe 'when not in production,' do
         it '.logging_ok? is true' do
-          expect(platform.logging_ok?).to eq true
+          expect(platform.logging_ok?).to be true
         end
       end
 
@@ -112,7 +112,7 @@ RSpec.describe Loba::Internal::Platform do
         end
 
         it '.logging_ok? is false' do
-          expect(platform.logging_ok?).to eq false
+          expect(platform.logging_ok?).to be false
         end
       end
     end
@@ -143,7 +143,7 @@ RSpec.describe Loba::Internal::Platform do
 
       describe 'when not in production,' do
         it '.logging_ok? is true' do
-          expect(platform.logging_ok?).to eq true
+          expect(platform.logging_ok?).to be true
         end
       end
 
@@ -154,7 +154,7 @@ RSpec.describe Loba::Internal::Platform do
         end
 
         it '.logging_ok? is false' do
-          expect(platform.logging_ok?).to eq false
+          expect(platform.logging_ok?).to be false
         end
       end
     end

--- a/spec/loba/loba/internal/platform_spec.rb
+++ b/spec/loba/loba/internal/platform_spec.rb
@@ -80,11 +80,11 @@ RSpec.describe Loba::Internal::Platform do
           .to receive(:env).and_return(LobaSpecSupport::MockRails::MockEnvNonproduction.new)
       end
 
-      it 'the Proc from .logger does not write to STDOUT' do
-        expect { platform.logger.call('test') }.not_to output.to_stdout
+      it 'the Proc from .logger writes intended output to STDOUT' do
+        expect { platform.logger.call('test') }.to output.to_stdout
       end
 
-      it 'the Proc from .logger writes to Rails.logger.debug' do
+      it 'the Proc from .logger writes intended output to Rails.logger.debug' do
         logging = object_double(mock_rails.logger)
         allow(mock_rails).to receive(:logger).and_return(logging)
         allow(logging).to receive(:debug)

--- a/spec/loba/loba/internal/platform_spec.rb
+++ b/spec/loba/loba/internal/platform_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Loba::Internal::Platform do
       end
 
       it 'the Proc from .logger writes intended output to STDOUT' do
-        expect { platform.logger.call('test') }.to output.to_stdout
+        expect { platform.logger.call('test') }.to output(/test/).to_stdout
       end
 
       it 'the Proc from .logger writes intended output to Rails.logger.debug' do
@@ -90,13 +90,17 @@ RSpec.describe Loba::Internal::Platform do
         allow(logging).to receive(:debug)
         allow(logging).to receive(:present?).and_return(true)
 
+        LobaSpecSupport::OutputControl.suppress!
         platform.logger.call('test')
         expect(logging).to have_received(:debug)
+        LobaSpecSupport::OutputControl.restore!
       end
 
       it 'Rails.logger.debug shows the intended output' do
+        LobaSpecSupport::OutputControl.suppress!
         platform.logger.call('test')
         expect(mock_rails.mocked_output.string).to end_with("test\n")
+        LobaSpecSupport::OutputControl.restore!
       end
 
       describe 'when not in production,' do

--- a/spec/loba/loba/internal/value_spec.rb
+++ b/spec/loba/loba/internal/value_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Loba::Internal::Value do
         let(:phrases) { object.symbol_without_label }
 
         it 'returns hash with expected keys' do
-          expect(phrases.keys).to match_array([:label, :line, :tag, :value])
+          expect(phrases.keys).to contain_exactly(:label, :line, :tag, :value)
         end
 
         it 'infers a default label' do
@@ -80,7 +80,7 @@ RSpec.describe Loba::Internal::Value do
         let(:phrases) { object.symbol_with_label }
 
         it 'returns hash with expected keys' do
-          expect(phrases.keys).to match_array([:label, :line, :tag, :value])
+          expect(phrases.keys).to contain_exactly(:label, :line, :tag, :value)
         end
 
         it 'uses supplied label' do
@@ -107,7 +107,7 @@ RSpec.describe Loba::Internal::Value do
         let(:phrases) { object.direct_without_label }
 
         it 'returns hash with expected keys' do
-          expect(phrases.keys).to match_array([:label, :line, :tag, :value])
+          expect(phrases.keys).to contain_exactly(:label, :line, :tag, :value)
         end
 
         it 'cannot infer a default label' do
@@ -132,7 +132,7 @@ RSpec.describe Loba::Internal::Value do
         let(:phrases) { object.direct_with_label }
 
         it 'returns hash with expected keys' do
-          expect(phrases.keys).to match_array([:label, :line, :tag, :value])
+          expect(phrases.keys).to contain_exactly(:label, :line, :tag, :value)
         end
 
         it 'uses supplied label' do
@@ -161,7 +161,7 @@ RSpec.describe Loba::Internal::Value do
       let!(:lineno) { __LINE__ } # must immediately follow `let(:phrases)`
 
       it 'returns hash with expected keys' do
-        expect(phrases.keys).to match_array([:label, :line, :tag, :value])
+        expect(phrases.keys).to contain_exactly(:label, :line, :tag, :value)
       end
 
       it 'infers a default label when no label supplied' do

--- a/spec/loba/loba/internal_spec.rb
+++ b/spec/loba/loba/internal_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe Loba::Internal do
     # custom matcher
     ##################
     matcher :be_changed_by_unquote do
-      # rubocop:disable RSpec/InstanceVariable
-
       match do |actual|
         @original = actual.freeze
         @unquoted = described_class.unquote(actual)
@@ -33,8 +31,6 @@ RSpec.describe Loba::Internal do
       def target?
         defined?(@target)
       end
-
-      # rubocop:enable RSpec/InstanceVariable
     end
 
     ##################

--- a/spec/loba/loba/version_spec.rb
+++ b/spec/loba/loba/version_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe 'Loba::VERSION' do
   end
 
   # ensure updates to VERSION are intentional
-  it 'is 1.x' do
-    expect(major).to eq 1
+  it 'is 2.x' do
+    expect(major).to eq 2
   end
 
-  it 'is 1.2.x or later' do
-    expect(minor).to be > 1
+  it 'is 2.0.x or later' do
+    expect(minor).to be >= 0
   end
 
   it 'has a patch value' do

--- a/spec/loba/loba/version_spec.rb
+++ b/spec/loba/loba/version_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe 'Loba::VERSION' do
   let(:parts) { version.match(/(\d+).(\d+)(?:.(\d+))?/) }
   let(:major) { parts[1].to_i }
   let(:minor) { parts[2].to_i }
-  let(:patch) { parts[3].nil? ? nil : parts[3].to_i }
+  let(:patch) { parts[3]&.to_i }
 
   it 'has a version number' do
-    expect(version).not_to be nil
+    expect(version).not_to be_nil
   end
 
   it 'is formatted as major.minor[.patch]' do

--- a/spec/loba/loba_spec.rb
+++ b/spec/loba/loba_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Loba do
   ### Use the above line (and comment out one below) to run performance checks
   describe 'profiling', skip: 'Ignore performance analysis during normal testing' do
     # rubocop:disable RSpec/InstanceVariable
-
     before do
       @profile = RubyProf::Profile.new
       @profile.exclude_methods!(Integer, :times)
@@ -30,14 +29,13 @@ RSpec.describe Loba do
       end
       @profile.stop
     end
-
     # rubocop:enable RSpec/InstanceVariable
 
-    it 'Loba.ts' do
+    it 'Loba.ts' do # rubocop:disable RSpec/NoExpectationExample
       run_profile { described_class.ts }
     end
 
-    it 'Loba.val' do
+    it 'Loba.val' do # rubocop:disable RSpec/NoExpectationExample
       _x = 5
       run_profile { described_class.val :_x }
     end

--- a/spec/loba_helper.rb
+++ b/spec/loba_helper.rb
@@ -8,4 +8,4 @@ require 'loba'
 # include spec/support
 Dir.glob(
   File.expand_path(File.join(File.dirname(__FILE__), 'support', '**', '*.rb'))
-).sort.each { |f| require f }
+).each { |f| require f }


### PR DESCRIPTION
* Update in prep of v2.0.0 release
* Drop support for Ruby prior to v3.0.6
* Write to STDOUT even when Rails present (still logs to Rails.logger.debug when Rails present)
* Various documentation improvements 
* Add SECURITY.md
* Update CHANGELOG.md